### PR TITLE
Add `return` transaction type and fix cut off tableview

### DIFF
--- a/Bulldog Bucks Swipes Widget/Info.plist
+++ b/Bulldog Bucks Swipes Widget/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.4</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionMainStoryboard</key>

--- a/Bulldog Bucks Watch Extension/Info.plist
+++ b/Bulldog Bucks Watch Extension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.4</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>CLKComplicationPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).ComplicationController</string>
 	<key>CLKComplicationSupportedFamilies</key>

--- a/Bulldog Bucks Watch/Info.plist
+++ b/Bulldog Bucks Watch/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.4</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>UIBackgroundModes</key>
 	<array/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/Bulldog Bucks Widget/Info.plist
+++ b/Bulldog Bucks Widget/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.4</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSExtension</key>

--- a/Bulldog Bucks/Base.lproj/LaunchScreen.storyboard
+++ b/Bulldog Bucks/Base.lproj/LaunchScreen.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina3_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -45,8 +46,8 @@
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ⓒ 2016 Rudy Bermudez" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="956-Yl-gDr">
-                                <rect key="frame" x="76.5" y="450" width="167" height="18"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ⓒ 2017 Rudy Bermudez" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="956-Yl-gDr">
+                                <rect key="frame" x="77.5" y="450" width="165.5" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>

--- a/Bulldog Bucks/Base.lproj/Main.storyboard
+++ b/Bulldog Bucks/Base.lproj/Main.storyboard
@@ -190,10 +190,10 @@
                                 <rect key="frame" x="0.0" y="20" width="320" height="548"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="1JC-vR-rVi">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="548"/>
                                         <subviews>
                                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" prefetchingEnabled="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gxM-mv-r3q">
-                                                <rect key="frame" x="0.0" y="0.0" width="320" height="189"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="320" height="182.5"/>
                                                 <color key="backgroundColor" red="0.36862745099999999" green="0.54117647059999996" blue="0.70588235290000001" alpha="1" colorSpace="calibratedRGB"/>
                                                 <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="Oum-OK-IGi">
                                                     <size key="itemSize" width="319" height="145"/>
@@ -203,7 +203,7 @@
                                                 </collectionViewFlowLayout>
                                                 <cells>
                                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="DetailCollectionViewCell" id="7Nn-dT-KOf" userLabel="BalanceCollectionViewCell" customClass="DetailCollectionViewCell" customModule="Bulldog_Bucks" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="22" width="319" height="145"/>
+                                                        <rect key="frame" x="0.0" y="19" width="319" height="145"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                                             <rect key="frame" x="0.0" y="0.0" width="319" height="145"/>
@@ -266,7 +266,7 @@
                                                         </connections>
                                                     </collectionViewCell>
                                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="GenericCollectionViewCell" id="lcG-p4-Th0" customClass="GenericCollectionViewCell" customModule="Bulldog_Bucks" customModuleProvider="target">
-                                                        <rect key="frame" x="319" y="22" width="319" height="145"/>
+                                                        <rect key="frame" x="319" y="19" width="319" height="145"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                                             <rect key="frame" x="0.0" y="0.0" width="319" height="145"/>
@@ -317,7 +317,7 @@
                                                         </connections>
                                                     </collectionViewCell>
                                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ButtonCollectionViewCell" id="BGJ-uB-y43" customClass="ButtonCollectionViewCell" customModule="Bulldog_Bucks" customModuleProvider="target">
-                                                        <rect key="frame" x="638" y="22" width="319" height="145"/>
+                                                        <rect key="frame" x="638" y="19" width="319" height="145"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                                             <rect key="frame" x="0.0" y="0.0" width="319" height="145"/>
@@ -438,7 +438,7 @@
                                                 </cells>
                                             </collectionView>
                                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="YV8-Tb-byW">
-                                                <rect key="frame" x="0.0" y="189" width="320" height="379"/>
+                                                <rect key="frame" x="0.0" y="182.5" width="320" height="365.5"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 <prototypes>
                                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="transactionCell" id="rNV-eB-4tF" customClass="TransactionTableViewCell" customModule="Bulldog_Bucks" customModuleProvider="target">
@@ -481,7 +481,7 @@
                                         </constraints>
                                     </stackView>
                                     <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" hidesForSinglePage="YES" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="Wgd-xl-Mlc">
-                                        <rect key="frame" x="140.5" y="169" width="39" height="10"/>
+                                        <rect key="frame" x="140.5" y="162.5" width="39" height="10"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="7Zz-R8-Jj2"/>
                                         </constraints>
@@ -499,7 +499,7 @@
                         </subviews>
                         <color key="backgroundColor" red="0.36862745098039218" green="0.54117647058823526" blue="0.70588235294117641" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="1JC-vR-rVi" firstAttribute="height" secondItem="0Ha-Up-WHq" secondAttribute="height" id="2vj-Ne-LKr"/>
+                            <constraint firstItem="1JC-vR-rVi" firstAttribute="height" secondItem="0Ha-Up-WHq" secondAttribute="height" constant="-20" id="2vj-Ne-LKr"/>
                             <constraint firstItem="Qyu-2I-WID" firstAttribute="top" secondItem="EFK-XJ-3l9" secondAttribute="bottom" id="ZoH-hv-YXI"/>
                             <constraint firstItem="EFK-XJ-3l9" firstAttribute="top" secondItem="0Ha-Up-WHq" secondAttribute="top" constant="20" id="bvQ-fh-fGw"/>
                             <constraint firstItem="1JC-vR-rVi" firstAttribute="width" secondItem="0Ha-Up-WHq" secondAttribute="width" id="ihL-GG-5nR"/>

--- a/Bulldog Bucks/Info.plist
+++ b/Bulldog Bucks/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Bulldog Bucks/Sources/View Controllers/TransactionViewController.swift
+++ b/Bulldog Bucks/Sources/View Controllers/TransactionViewController.swift
@@ -309,10 +309,10 @@ extension TransactionViewController: UITableViewDataSource {
         
         cell.amountLabel.text = transaction.prettyAmount
         
-        if transaction.type == .deposit {
-            cell.amountLabel.textColor = UIColor(red: 106.0/255.0, green: 148.0/255.0, blue: 88.0/255.0, alpha: 1.0)
-        } else {
+        if transaction.type == .sale {
             cell.amountLabel.textColor = UIColor.gray
+        } else {
+            cell.amountLabel.textColor = UIColor(red: 106.0/255.0, green: 148.0/255.0, blue: 88.0/255.0, alpha: 1.0)
         }
         return cell
         

--- a/Shared/API/ZagwebAPI.swift
+++ b/Shared/API/ZagwebAPI.swift
@@ -291,7 +291,7 @@ final class ZagwebClient {
                         // 2. Neglect the first row because it solely has labels in it
                         // 3. See if the transaction can be parsed
                         if let rowData = rowData, rowData.count == 7, rowData[0] != "Transaction Date",
-                            let transaction = Transaction(date: rowData[0], venue: rowData[1], amount: rowData[3], type: rowData[6].lowercased() ) {
+                            let transaction = Transaction(date: rowData[0], venue: rowData[1], amount: rowData[3], type: rowData[6]) {
             
                             // Assuming all checks pass, append the data
                             transactions.append(transaction)

--- a/Shared/Models/Transaction.swift
+++ b/Shared/Models/Transaction.swift
@@ -12,6 +12,7 @@ import Foundation
 enum TransactionType: String {
     case sale
     case deposit
+    case `return`
 }
 
 struct Transaction {
@@ -36,7 +37,7 @@ struct Transaction {
             .replacingOccurrences(of: ")", with: "")
             ),
             let formattedDate = dateFormatter.date(from: date),
-            let transactionType = TransactionType(rawValue: type) else {
+            let transactionType = TransactionType(rawValue: type.lowercased()) else {
             return nil
         }
         
@@ -94,6 +95,8 @@ extension Transaction: CustomStringConvertible {
             return String(format: "+$%.2f", amount)
         case .sale:
             return String(format: "-$%.2f", amount)
+        case .return:
+            return String(format: "+$%.2f", amount)
         }
     }
 }


### PR DESCRIPTION
Update Copyright to 2017 on launch screen, fixed bug where tableview was cut off on the very bottom by 20 px, added the ability to recognize `Returns` as a type of transaction, bumped to 1.3.4 build 13