### PR TITLE
Fix tableview header date label

### DIFF
--- a/Bulldog Bucks Swipes Widget/Info.plist
+++ b/Bulldog Bucks Swipes Widget/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.4</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionMainStoryboard</key>

--- a/Bulldog Bucks Watch Extension/Info.plist
+++ b/Bulldog Bucks Watch Extension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.4</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>CLKComplicationPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).ComplicationController</string>
 	<key>CLKComplicationSupportedFamilies</key>

--- a/Bulldog Bucks Watch/Info.plist
+++ b/Bulldog Bucks Watch/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.4</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>UIBackgroundModes</key>
 	<array/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/Bulldog Bucks Widget/Info.plist
+++ b/Bulldog Bucks Widget/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.4</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSExtension</key>

--- a/Bulldog Bucks/Info.plist
+++ b/Bulldog Bucks/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Shared/Models/Transaction.swift
+++ b/Shared/Models/Transaction.swift
@@ -63,6 +63,7 @@ extension Transaction: CustomStringConvertible {
         return dateFormatter.string(from: date)
     }
     
+    // Just the date without the time
     var dateForSorting: Date {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "M/d/yyyy"
@@ -73,18 +74,18 @@ extension Transaction: CustomStringConvertible {
     }
     
     var sectionHeaderDate: String {
-        if Calendar.current.compare(date, to: Date(), toGranularity: .day) == .orderedSame {
+        if Calendar.current.compare(dateForSorting, to: Date(), toGranularity: .day) == .orderedSame {
             return "Today"
-        } else if (date as NSDate).days(to: Date()) == 1 {
+        } else if (dateForSorting as NSDate).days(to: Date()) == 1 {
             return "Yesterday"
-        } else if Calendar.current.compare(date, to: Date(), toGranularity: .year) == .orderedSame {
+        } else if Calendar.current.compare(dateForSorting, to: Date(), toGranularity: .year) == .orderedSame {
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "MMMM d"
-            return dateFormatter.string(from: date)
+            return dateFormatter.string(from: dateForSorting)
         } else {
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "MMMM d, yyyy"
-            return dateFormatter.string(from: date)
+            return dateFormatter.string(from: dateForSorting)
         }
         
     }


### PR DESCRIPTION
I fixed an error where the header of the transaction tableview would not show “Yesterday” if the transaction occured less than 24 hours from the present time, even if it was a different calendar date.  I fixed it by removing the hour and minute of a transaction when the date is being compared in order to return the sectionHeader text.

bump to 1.3.4 b15